### PR TITLE
add configuration file to be able to keep user configuration when pulling new versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+seafile_updater.conf

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # seafile_rpi_bash_upgrader
+
+Updates the Raspberry Pi version of an installed seafile server
+
+### Usage
+
+The script needs to be run with `root`-privileges.  
+
+1. Use the file `seafile_updater.conf.template` as template to create a configuration file named `seafile_updater.conf` in the scripts directory and adjust variables to fit your needs.  
+2. Run the script with `./seafile_updater.sh`.  

--- a/seafile_updater.conf.template
+++ b/seafile_updater.conf.template
@@ -1,0 +1,34 @@
+######## template configuration file for seafile_updater.sh ########
+#
+### copy this file to a file named 'seafile_updater.conf' in scripts directory and set
+### variables in 'seafile_updater.conf' according to the setup of your seafile server
+#
+### the script is written in such a manner that it's important to write a trailing slashs on the variable dir names
+#
+#####################################################################
+
+
+# set to true for https usage on your seafile system:
+https=true
+
+
+# the URL of your seafile server (without trailing slash):
+domain=""
+
+
+# user and group of your seafile server:
+sea_user=""
+sea_grp=""
+
+
+# directory to store temporary files (with trailing slash):
+tmp_dir=""
+
+
+# directory of your seafile server (with trailing slash):
+sea_dir=""
+
+
+# logging options. Not yet implemented!
+#log_path="/var/log/"
+#log_file="seafile_updater_$(/bin/date -I)"

--- a/seafile_updater.sh
+++ b/seafile_updater.sh
@@ -4,7 +4,7 @@
 #### description: semi automatic seafile rpi server version updater
 #### ~build from reference: https://manual.seafile.com/deploy/upgrade.html
 #### written by Max Roessler - mailmax@web.de on 07.07.2018
-#### Version: 0.9
+#### Version: 0.9.1
 ############################################################################
 
 ######## variable setup ########
@@ -15,15 +15,9 @@ grn=$'\e[1;32m'
 red=$'\e[1;31m'
 end=$'\e[0m'
 
-### the script is written in such a manner that it's important to write a trailing slashs on the variable dir names
-https=true #set to true for https usage on your seafile system
-domain=""
-sea_user=""
-sea_grp=""
-tmp_dir=""
-sea_dir=""
-#log_path="/var/log/"
-#log_file="seafile_updater_$(/bin/date -I)"
+### include configuration file with user assigned variables ###
+. seafile_updater.conf || { echo "-- Configuration file 'seafile_updater.conf' not found. See file 'seafile_updater.conf.template'"; exit 1; }
+
 ################################
 
 ### Before starting the script it must be checked manually if other necessary dependencies like new packages are needed to be installed, like on some releases already before. Please look at release notes: https://github.com/haiwen/seafile-rpi/releases/latest


### PR DESCRIPTION
This pull requests adds a configuration file.
This is useful for future versions of this script, because currently users will have their configuration within the script overwritten every time they pull a new version and thus to fill everything out again. Not so much work with this script, but could still be a bit annoying. A separate configuration file not tracked from git solves this.