### PR TITLE
adapt retrieving version numbers

### DIFF
--- a/seafile_updater.sh
+++ b/seafile_updater.sh
@@ -105,7 +105,7 @@ else
                 exit 1
         fi
         ### setting right folder and file permissions on new folder structure
-	      /bin/chown -R "${sea_user}":"${sea_grp}" "${sea_dir}seafile-server-${git_ver}"/ || { /bin/echo "${red}chown the new server sea_dir failed${end}"; exit 1; }
+	/bin/chown -R "${sea_user}":"${sea_grp}" "${sea_dir}seafile-server-${git_ver}"/ || { /bin/echo "${red}chown the new server sea_dir failed${end}"; exit 1; }
         ### stop all services from seafile before update started
         /bin/systemctl stop seafile.service seahub.service || { /bin/echo "${red}stop the seafile and/or seahub service failed${end}"; exit 1; }
         ### compare versions if there is a major or minor version upgrade needed
@@ -121,7 +121,7 @@ else
                         IFS="${old_ifs}"
                         ### search for necessary update scripts
                         if [ "${script_major}" -gt "${serv_major}" ] || [ "${script_major}" -eq "${serv_major}" ] && [ "${script_minor}" -ge "${serv_minor}" ]; then
-	                	    /bin/su - "${sea_user}" -s /bin/bash -c "cd ${sea_dir}seafile-server-${git_ver}/ && upgrade/${script}" || { /bin/echo "${red}update script failed!${end}"; exit 1; }
+	                /bin/su - "${sea_user}" -s /bin/bash -c "cd ${sea_dir}seafile-server-${git_ver}/ && upgrade/${script}" || { /bin/echo "${red}update script failed!${end}"; exit 1; }
                         fi
                 done
         ### compare versions if there is a maint version upgrade needed
@@ -148,7 +148,7 @@ else
         fi
         if [ "${git_ver}" == "${verify_ver}" ]; then
                 ### move old seafile version to installed dir as an archive for a possible rollback scenario
-		            /bin/mv "${sea_dir}seafile-server-${serv_ver}" "${sea_dir}installed/" || { /bin/echo "${red}move to archive dir failed${end}"; exit 1; }
+		/bin/mv "${sea_dir}seafile-server-${serv_ver}" "${sea_dir}installed/" || { /bin/echo "${red}move to archive dir failed${end}"; exit 1; }
                 ### delete old temporary files and archives
                 /bin/rm -rf "${tmp_dir}seafile-server_${git_ver}_stable_pi.tar.gz" || { /bin/echo "${red}remove temporary files and directories failed${end}"; exit 1; }
         else


### PR DESCRIPTION
Due to adding a new feature to encrypted libraries the output of `{seafile-server}api2/server-info/` has changed in seafile version 7.0:
```
curl -s {seafile-server-6.3.4}/api2/server-info/
{"version": "6.3.4", "features": ["seafile-basic"]}
curl -s {seafile-server-7.0.4}/api2/server-info/
{"version": "7.0.4", "encrypted_library_version": 2, "features": ["seafile-basic"]}
```
This makes the script break due to not being able to recognize the correct server version when updating to 7.0 from a version < 7.0 at the end of the script and in future upgrades already in the beginning of the script.

I adapted the script to the new output of `/api2/server-info/` with a more failsafe solution using bash builtin parameter expansion.
Additional benefit is that the external program `awk` is not needed anymore which saves some resources.

EDIT:
for possibly needed background information about parameter expansion in Bash see here:
https://manpages.debian.org/buster/bash/bash.1.en.html
or here:
http://wiki.bash-hackers.org/syntax/pe#substring_removal