### PR TITLE
Only delete own files from tmp_dir

### DIFF
--- a/seafile_updater.sh
+++ b/seafile_updater.sh
@@ -143,7 +143,7 @@ else
                 ### move old seafile version to installed dir as an archive for a possible rollback scenario
 		/bin/mv "${sea_dir}seafile-server-${serv_ver}" "${sea_dir}installed/" || { /bin/echo "${red}move to archive dir failed${end}"; exit 1; }
                 ### delete old temporary files and archives
-                /bin/rm -rf "${tmp_dir}"* || { /bin/echo "${red}remove temporary files and directories failed${end}"; exit 1; }
+                /bin/rm -rf "${tmp_dir}seafile-server_${git_ver}_stable_pi.tar.gz" || { /bin/echo "${red}remove temporary files and directories failed${end}"; exit 1; }
         else
                 echo "${red}a bigger problem is occured, no new version was installed!${end}"
         fi


### PR DESCRIPTION
In case the user chooses as `tmp_dir` a temporary directory (like `/tmp/` or `/var/tmp/`) which is also being used by other programs, it would be better to only remove files created from the script (after a successful run this is only the seafile-archive) rather than wiping the whole directory (which may lead to undesired behaviour of other programs).